### PR TITLE
docs: announce Windows source branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@
 
 ## 🔥 News
 
+- **[2026-04-10]** 🪟 [Windows release published](https://github.com/louiszengCN/CarlaAir/releases/tag/v0.1.7-win11-x86_64) -- native Windows 11 x86_64 build is now available in Releases
 - **[2026-04-01]** 🏆 $\color{red}{\textbf{\\#1 Paper of the Day}}$ **on [Hugging Face Daily Papers](https://huggingface.co/papers/2603.28032)!**
 - **[2026-03-30]** 📄 Technical report released -- [Read the paper](https://arxiv.org/abs/2603.28032)
 - **[2026-03]** `v0.1.7` released -- VSync fix, stable traffic, one-click env setup, drone recording toolkit, coordinate docs

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 
 ## 🔥 News
 
-- **[2026-04-10]** 🪟 [Windows release published](https://github.com/louiszengCN/CarlaAir/releases/tag/v0.1.7-win11-x86_64) -- native Windows 11 x86_64 build is now available in Releases
+- **[2026-04-10]** 🪟 [Windows source branch published](https://github.com/louiszengCN/CarlaAir/tree/windows/v0.1.7-win11-x86_64) -- Windows build and runtime support is now available on the dedicated branch
 - **[2026-04-01]** 🏆 $\color{red}{\textbf{\\#1 Paper of the Day}}$ **on [Hugging Face Daily Papers](https://huggingface.co/papers/2603.28032)!**
 - **[2026-03-30]** 📄 Technical report released -- [Read the paper](https://arxiv.org/abs/2603.28032)
 - **[2026-03]** `v0.1.7` released -- VSync fix, stable traffic, one-click env setup, drone recording toolkit, coordinate docs

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,6 +58,7 @@
 
 ## 🔥 最新动态
 
+- **[2026-04-10]** 🪟 [Windows 发行版已发布](https://github.com/louiszengCN/CarlaAir/releases/tag/v0.1.7-win11-x86_64) -- 可在 Releases 下载原生 Windows 11 x86_64 构建
 - **[2026-04-01]** 🏆 $\color{red}{\textbf{\\#1 Paper of the Day}}$ **登顶 [Hugging Face Daily Papers](https://huggingface.co/papers/2603.28032)！**
 - **[2026-03-30]** 📄 技术报告发布 -- [阅读论文](https://arxiv.org/abs/2603.28032)
 - **[2026-03-31]** 🚀 即将上线 -- 项目主页、教程文档及开箱即用的二进制发布包，敬请期待！

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,7 +58,7 @@
 
 ## 🔥 最新动态
 
-- **[2026-04-10]** 🪟 [Windows 发行版已发布](https://github.com/louiszengCN/CarlaAir/releases/tag/v0.1.7-win11-x86_64) -- 可在 Releases 下载原生 Windows 11 x86_64 构建
+- **[2026-04-10]** 🪟 [Windows 源码分支已发布](https://github.com/louiszengCN/CarlaAir/tree/windows/v0.1.7-win11-x86_64) -- Windows 构建与运行支持现已在独立分支中提供
 - **[2026-04-01]** 🏆 $\color{red}{\textbf{\\#1 Paper of the Day}}$ **登顶 [Hugging Face Daily Papers](https://huggingface.co/papers/2603.28032)！**
 - **[2026-03-30]** 📄 技术报告发布 -- [阅读论文](https://arxiv.org/abs/2603.28032)
 - **[2026-03-31]** 🚀 即将上线 -- 项目主页、教程文档及开箱即用的二进制发布包，敬请期待！


### PR DESCRIPTION
## Summary
- add a News entry to README.md
- add a synced News entry to README_CN.md
- point both entries to the dedicated Windows source branch

## Notes
- this PR intentionally keeps main minimal
- Windows source changes live on branch windows/v0.1.7-win11-x86_64
- no Windows runtime binaries are committed into the repository tree