### PR TITLE
fix(windows): load requested map after startup

### DIFF
--- a/CarlaAir.ps1
+++ b/CarlaAir.ps1
@@ -104,6 +104,41 @@ function Resolve-TrafficPython {
     return $null
 }
 
+function Invoke-CarlaMapLoad {
+    param(
+        [string]$PythonExe,
+        [string]$MapName,
+        [int]$Port
+    )
+
+    $code = @'
+import sys
+import carla
+
+map_name = sys.argv[1]
+port = int(sys.argv[2])
+
+client = carla.Client('127.0.0.1', port)
+client.set_timeout(60.0)
+
+world = client.get_world()
+current = world.get_map().name
+if not current.endswith('/' + map_name):
+    world = client.load_world(map_name)
+    current = world.get_map().name
+
+if not current.endswith('/' + map_name):
+    raise RuntimeError(f'expected {map_name}, got {current}')
+
+print(current)
+'@
+
+    & $PythonExe -c $code $MapName $Port
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to load CARLA map '$MapName'."
+    }
+}
+
 function Resolve-CarlaBinary {
     param([string]$RepoRoot, [string]$ExplicitPackageRoot)
 
@@ -250,6 +285,7 @@ if ($showLog) {
 
 $binaryInfo = Resolve-CarlaBinary -RepoRoot $repoRoot -ExplicitPackageRoot $explicitPackageRoot
 $trafficPython = if ($autoTraffic) { Resolve-TrafficPython -ExplicitPath $explicitPython } else { $null }
+$carlaPython = if ($trafficPython) { $trafficPython } else { Resolve-TrafficPython -ExplicitPath $explicitPython }
 
 $airsimSettingsSource = Join-Path $repoRoot "AirSimConfig\settings.json"
 if (-not (Test-Path $airsimSettingsSource)) {
@@ -335,6 +371,22 @@ for ($attempt = 0; $attempt -lt 60; $attempt++) {
 }
 if (-not $airsimReady) {
     throw "AirSim port $airsimPort did not become ready within 120 seconds. Check $logFile"
+}
+
+if ($carlaPython) {
+    Write-Host "Verifying CARLA map..."
+    for ($attempt = 1; $attempt -le 6; $attempt++) {
+        try {
+            Invoke-CarlaMapLoad -PythonExe $carlaPython -MapName $mapName -Port $carlaPort
+            break
+        } catch {
+            if ($attempt -eq 6) { throw }
+            Write-Warning "CARLA map verification attempt $attempt failed. Retrying..."
+            Start-Sleep -Seconds 5
+        }
+    }
+} else {
+    Write-Warning "Could not verify or force-load map '$mapName' because no Python with the 'carla' module was found."
 }
 
 if ($autoTraffic) {


### PR DESCRIPTION
Fixes #28.

## Root cause

On the Windows v0.1.7 binary package, `CarlaAir.ps1` accepts a map argument such as `Town01`/`Town03` and passes it to the packaged simulator, but the CARLA world can still come up as the default `Town10HD`. In other words, the launcher argument is visible at the process level, but it is not a reliable guarantee that the requested CARLA world is the one that actually got loaded.

This matches the issue report: launching with `CarlaAir.ps1 Town01` or changing `$mapName` still results in `Town10HD`.

## What changed

- Added a small `Invoke-CarlaMapLoad` helper in the Windows launcher.
- After both CARLA and AirSim ports are ready, the launcher connects through the CARLA Python API and checks `world.get_map().name`.
- If the active world does not match the requested map, the launcher calls `client.load_world(map_name)`.
- Added a short retry loop because the TCP port can be open before CARLA RPC is fully ready to answer map operations.
- Reuses the launcher existing Python discovery path (`--python`, `CARLAAIR_PYTHON_EXE`, system `python`, or the `carlaAir` conda environment). If no Python with `carla` is available, startup continues with a warning.

## What this fixes

The Windows launcher now verifies the actual CARLA world after startup instead of assuming the startup map argument took effect. When users start the binary package with a non-default map, the simulator is forced onto that requested map before the launcher reports ready.

Verified with the Windows launcher directly:

```powershell
.\CarlaAir.ps1 Town03 --no-traffic --package-root <WindowsNoEditor> --python <python-with-carla>
```

Observed launcher output:

```text
Verifying CARLA map...
Carla/Maps/Town03
CarlaAir is ready.
```