### PR TITLE
fix(windows): load requested map after startup

### DIFF
--- a/CarlaAir.ps1
+++ b/CarlaAir.ps1
@@ -104,6 +104,52 @@ function Resolve-TrafficPython {
     return $null
 }
 
+function Test-CarlaPython {
+    param([string]$PythonExe)
+
+    if (-not $PythonExe) {
+        return $false
+    }
+
+    & $PythonExe -c "import carla" 2>$null
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Invoke-CarlaMapLoad {
+    param(
+        [string]$PythonExe,
+        [string]$MapName,
+        [int]$Port
+    )
+
+    $code = @'
+import sys
+import carla
+
+map_name = sys.argv[1]
+port = int(sys.argv[2])
+
+client = carla.Client('127.0.0.1', port)
+client.set_timeout(60.0)
+
+world = client.get_world()
+current = world.get_map().name
+if not current.endswith('/' + map_name):
+    world = client.load_world(map_name)
+    current = world.get_map().name
+
+if not current.endswith('/' + map_name):
+    raise RuntimeError(f'expected {map_name}, got {current}')
+
+print(current)
+'@
+
+    & $PythonExe -c $code $MapName $Port
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to load CARLA map '$MapName'."
+    }
+}
+
 function Resolve-CarlaBinary {
     param([string]$RepoRoot, [string]$ExplicitPackageRoot)
 
@@ -250,6 +296,10 @@ if ($showLog) {
 
 $binaryInfo = Resolve-CarlaBinary -RepoRoot $repoRoot -ExplicitPackageRoot $explicitPackageRoot
 $trafficPython = if ($autoTraffic) { Resolve-TrafficPython -ExplicitPath $explicitPython } else { $null }
+$carlaPython = if ($trafficPython) { $trafficPython } else { Resolve-TrafficPython -ExplicitPath $explicitPython }
+if ($carlaPython -and -not (Test-CarlaPython -PythonExe $carlaPython)) {
+    throw "Python path does not provide the 'carla' module: $carlaPython"
+}
 
 $airsimSettingsSource = Join-Path $repoRoot "AirSimConfig\settings.json"
 if (-not (Test-Path $airsimSettingsSource)) {
@@ -335,6 +385,22 @@ for ($attempt = 0; $attempt -lt 60; $attempt++) {
 }
 if (-not $airsimReady) {
     throw "AirSim port $airsimPort did not become ready within 120 seconds. Check $logFile"
+}
+
+if ($carlaPython) {
+    Write-Host "Verifying CARLA map..."
+    for ($attempt = 1; $attempt -le 6; $attempt++) {
+        try {
+            Invoke-CarlaMapLoad -PythonExe $carlaPython -MapName $mapName -Port $carlaPort
+            break
+        } catch {
+            if ($attempt -eq 6) { throw }
+            Write-Warning "CARLA map verification attempt $attempt failed. Retrying..."
+            Start-Sleep -Seconds 5
+        }
+    }
+} else {
+    Write-Warning "Could not verify or force-load map '$mapName' because no Python with the 'carla' module was found."
 }
 
 if ($autoTraffic) {


### PR DESCRIPTION
Fixes #28.

## Root cause

On the Windows v0.1.7 binary package, `CarlaAir.ps1` accepts a requested map name such as `Town01` or `Town03`, but the packaged simulator can still finish startup with the default `Town10HD` world. The map argument is passed to the process, but the active CARLA world is not reliably the requested map.

## What changed

- Add `Invoke-CarlaMapLoad` to verify the active CARLA map through the CARLA Python API after startup.
- If `world.get_map().name` does not match the requested map, call `client.load_world(map_name)`.
- Add a short retry loop because CARLA RPC can lag behind the TCP port readiness check.
- Validate that the selected Python executable can import `carla`, so a wrong `--python` path fails with a clear error.
- Reuse the launcher existing Python discovery path; no new launcher dependency is introduced.

## Result

The Windows launcher no longer assumes the startup map argument took effect. Before reporting ready, it verifies the actual CARLA world and loads the requested map if needed.

Validated with the Windows launcher directly:

```powershell
.\CarlaAir.ps1 Town03 --no-traffic --package-root <WindowsNoEditor> --python <python-with-carla>
```

Observed output:

```text
Verifying CARLA map...
Carla/Maps/Town03
CarlaAir is ready.
```